### PR TITLE
Add custom mapper hook and UKLFR mappers

### DIFF
--- a/ahd2fhir/config.py
+++ b/ahd2fhir/config.py
@@ -39,3 +39,6 @@ class Settings(BaseSettings):
     # the expected time for normal rebalances.
     kafka_heartbeat_interval_ms: int = 3000
     kafka_auto_offset_reset: str = "earliest"
+
+    # Enable UKLFR Anntation mappers
+    custom_mappers_enabled: bool = False

--- a/ahd2fhir/config.py
+++ b/ahd2fhir/config.py
@@ -33,6 +33,10 @@ class Settings(BaseSettings):
     kafka_ssl_keyfile: str = path.join(TLS_ROOT_DIR, "user.key")
     kafka_auto_commit_interval_ms: int = 5000
     kafka_session_timeout_ms: int = 15000
+    # kafka_sasl_plain_username: str = None
+    # kafka_sasl_plain_password: str = None
+    # kafka_sasl_mechanism: str = None
+
     # The value must be set lower than session_timeout_ms,
     # but typically should be set no higher than 1/3 of
     # that value. It can be adjusted even lower to control

--- a/ahd2fhir/config.py
+++ b/ahd2fhir/config.py
@@ -39,6 +39,3 @@ class Settings(BaseSettings):
     # the expected time for normal rebalances.
     kafka_heartbeat_interval_ms: int = 3000
     kafka_auto_offset_reset: str = "earliest"
-
-    # Enable UKLFR Anntation mappers
-    custom_mappers_enabled: bool = False

--- a/ahd2fhir/mappers/ahd_to_observation_kidney_stone.py
+++ b/ahd2fhir/mappers/ahd_to_observation_kidney_stone.py
@@ -1,0 +1,175 @@
+import datetime
+import uuid
+from typing import List
+
+from fhir.resources.codeableconcept import CodeableConcept
+from fhir.resources.coding import Coding
+from fhir.resources.documentreference import DocumentReference
+from fhir.resources.fhirtypes import DateTime, QuantityType, ReferenceType
+from fhir.resources.meta import Meta
+from fhir.resources.observation import Observation
+from structlog import get_logger
+
+log = get_logger()
+
+CLINICAL_STATUS_MAPPING = {"ACTIVE": "active", "RESOLVED": "resolved"}
+SIDE_MAPPING = {
+    "LEFT": ("7771000", "Left"),
+    "RIGHT": ("24028007", "Right"),
+    "BOTH": ("51440002", "Right and left"),
+}
+
+UNIT_MAPPING = {"cm": "258672001", "mm": "258673006"}
+
+OBSERVATION_PROFILE = (
+    "https://www.medizininformatik-initiative.de/"
+    + "fhir/core/StructureDefinition/Observation"
+)
+UKLFR_TYPE_KIDNEY_STONE = "de.uklfr.KidneyStoneAnnotator.KidneyStoneInfo"
+
+OBSERVATION_CATEGORY_SYSTEM = (
+    "http://terminology.hl7.org/CodeSystem/observation-category"
+)
+
+STONE_DIMENSION_MAP = {
+    "width": {
+        "code": "9805-3",
+        "name": "Width of Stone",
+        "display": "Width (Stone) [Length]",
+    },
+    "length": {
+        "code": "9799-8",
+        "name": "Length of Stone",
+        "display": "Length (Stone) [Length]",
+    },
+}
+
+
+def get_fhir_kidney_stone_observations(
+    ahd_response_entry, document_reference: DocumentReference
+) -> List[Observation]:
+    return get_kidney_stone_from_annotation(
+        annotation=ahd_response_entry,
+        date=document_reference.date,
+        doc_ref=document_reference,
+    )
+
+
+def fhirdate_now() -> DateTime:
+    return DateTime.validate(datetime.datetime.now(datetime.timezone.utc))
+
+
+def get_kidney_stone_from_annotation(
+    annotation, date, doc_ref: DocumentReference
+) -> List[Observation]:
+    # Observation details
+    observation = Observation.construct()
+    observation.status = "final"
+    observation.meta = Meta.construct()
+    observation.meta.profile = [OBSERVATION_PROFILE]
+    observation.subject = doc_ref.subject
+    observation.effectiveDateTime = date or fhirdate_now()
+    observation.id = str(uuid.uuid4())
+
+    # Coding + Code
+    observation_coding = Coding.construct()
+    observation_coding.system = "http://snomed.info/sct"
+    observation_coding.code = "95570007"
+    observation_coding.display = "Kidney stone (disorder)"
+    observation_coding.userSelected = False
+    observation_code = CodeableConcept.construct()
+    observation_code.coding = [observation_coding]
+    observation_code.text = "Kidney stone"
+    observation.code = observation_code
+
+    # Category
+    observation_category = Coding.construct()
+    observation_category.system = OBSERVATION_CATEGORY_SYSTEM
+    observation_category.code = "imaging"
+    observation_category.display = "Imaging"
+    category = CodeableConcept.construct()
+    category.coding = [observation_category]
+    observation.category = [category]
+
+    # Method
+    observation_method = Coding.construct()
+    observation_method.system = "http://snomed.info/sct"
+    observation_method.code = "363680008"
+    observation_method.display = " Radiographic imaging procedure"
+    method = CodeableConcept.construct()
+    method.coding = [observation_method]
+    observation.method = method
+
+    # valueCodeableConcept
+    value_codeable_concept = CodeableConcept()
+    value_coding = Coding.construct()
+    value_coding.system = "http://snomed.info/sct"
+    value_coding.code = "56381008"
+    value_codeable_concept.coding = [value_coding]
+    value_codeable_concept.text = "Calculus (morphologic abnormality)"
+    observation.valueCodeableConcept = value_codeable_concept
+
+    observations = [observation]
+
+    # Create Observation for each Dimension (X/Y)
+    if (stone_size := annotation["size"]) is not None:
+        observation.hasMember = []
+        stone_unit = stone_size["unit"]["coveredText"]
+        stone_len = stone_size["value1"]
+        stone_len_obs = stone_dimension_observation(
+            observation, "length", stone_len, unit=stone_unit
+        )
+        observation.hasMember.append(stone_len_obs[1])
+        observations.append(stone_len_obs[0])
+
+        stone_width = stone_size["value2"]
+        if stone_width in [0, "0"]:
+            stone_width = stone_len
+        stone_width_obs = stone_dimension_observation(
+            observation, "width", stone_width, unit=stone_unit
+        )
+        observation.hasMember.append(stone_width_obs[1])
+        observations.append(stone_width_obs[0])
+
+    return observations
+
+
+def stone_dimension_observation(
+    parent: Observation, dimension: str, value: float, unit: str
+):
+    dimension_type = STONE_DIMENSION_MAP[dimension]
+    # Observation details
+    observation = Observation.construct()
+    observation.status = "final"
+    observation.meta = Meta.construct()
+    observation.meta.profile = [OBSERVATION_PROFILE]
+    observation.subject = parent.subject
+    observation.effectiveDateTime = parent.effectiveDateTime
+    observation.id = str(uuid.uuid4())
+
+    # Coding
+    observation_coding = Coding.construct()
+    observation_coding.system = "http://loinc.org"
+    observation_coding.code = dimension_type["code"]
+    observation_coding.display = dimension_type["display"]
+    observation_coding.userSelected = False
+    # Code
+    observation_code = CodeableConcept.construct()
+    observation_code.coding = [observation_coding]
+    observation_code.text = dimension_type["name"]
+    observation.code = observation_code
+
+    # valueCodeableConcept
+    value_quantity = QuantityType()
+    value_quantity["system"] = "http://unitsofmeasure.org"
+    value_quantity["code"] = unit
+    value_quantity["value"] = value
+    value_quantity["unit"] = {"mm": "Millimeter", "cm": "Centimeter"}[unit]
+    observation.valueQuantity = value_quantity
+
+    # Create Reference to Observation
+    observation_reference = ReferenceType()
+    observation_reference["reference"] = f"Observation/{observation.id}"
+    observation_reference["display"] = observation.code.coding[0].display
+
+    return observation, observation_reference

--- a/ahd2fhir/mappers/ahd_to_observation_kidney_stone.py
+++ b/ahd2fhir/mappers/ahd_to_observation_kidney_stone.py
@@ -26,6 +26,7 @@ OBSERVATION_PROFILE = (
     + "fhir/core/StructureDefinition/Observation"
 )
 UKLFR_TYPE_KIDNEY_STONE = "de.uklfr.KidneyStoneAnnotator.KidneyStoneInfo"
+AHD_TYPE = UKLFR_TYPE_KIDNEY_STONE
 
 OBSERVATION_CATEGORY_SYSTEM = (
     "http://terminology.hl7.org/CodeSystem/observation-category"
@@ -45,7 +46,7 @@ STONE_DIMENSION_MAP = {
 }
 
 
-def get_fhir_kidney_stone_observations(
+def get_fhir_resources(
     ahd_response_entry, document_reference: DocumentReference
 ) -> List[Observation]:
     return get_kidney_stone_from_annotation(

--- a/ahd2fhir/mappers/ahd_to_observation_smkstat.py
+++ b/ahd2fhir/mappers/ahd_to_observation_smkstat.py
@@ -1,0 +1,118 @@
+import datetime
+import uuid
+
+from fhir.resources.codeableconcept import CodeableConcept
+from fhir.resources.coding import Coding
+from fhir.resources.documentreference import DocumentReference
+from fhir.resources.fhirtypes import DateTime
+from fhir.resources.meta import Meta
+from fhir.resources.observation import Observation
+from structlog import get_logger
+
+log = get_logger()
+
+OBSERVATION_PROFILE = (
+    "https://www.medizininformatik-initiative.de/"
+    + "fhir/core/StructureDefinition/Observation"
+)
+UKLFR_TYPE_SMKSTAT = "de.medunifreiburg.imbi.mds.extraction.types.Smoking"
+
+OBSERVATION_CATEGORY_SYSTEM = (
+    "http://terminology.hl7.org/CodeSystem/observation-category"
+)
+
+SNOMED_LOINC_MAPPING = {
+    "PAST-SMOKER": {"code": "LA15920-4", "text": "Former smoker"},
+    "CURRENT-SMOKER": {"code": "LA18976-3", "text": "Current every day smoker"},
+    "CURRENT-NON-SMOKER": {"code": "LA15920-4", "text": "Former smoker"},
+    "NEVER-SMOKER": {"code": "LA18978-9", "text": "Never smoker"},
+    "CURRENT-OR-PAST-SMOKER": {
+        "code": "LA18979-7",
+        "text": "Smoker, current status unknown",
+    },
+    "UNKNOW": {"code": "LA18980-5", "text": "Unknown if ever smoked"},
+}
+
+
+def get_fhir_observation(
+    ahd_response_entry, document_reference: DocumentReference
+) -> Observation:
+    return get_smoking_status_observation_from_annotation(
+        annotation=ahd_response_entry,
+        date=document_reference.date,
+        doc_ref=document_reference,
+    )
+
+
+def fhirdate_now():
+    return DateTime.validate(datetime.datetime.now(datetime.timezone.utc))
+
+
+def get_smoking_status_observation_from_annotation(
+    annotation, date, doc_ref: DocumentReference
+):
+    # Observation details
+    observation = Observation.construct()
+    observation.status = "final"
+    observation.meta = Meta.construct()
+    observation.meta.profile = [OBSERVATION_PROFILE]
+    observation.subject = doc_ref.subject
+    observation.effectiveDateTime = date or fhirdate_now()
+    observation.id = str(uuid.uuid4())
+
+    # Coding
+    observation_coding = Coding.construct()
+    observation_coding.system = "http://loinc.org"
+    observation_coding.code = "72166-2"
+    observation_coding.display = "Tobacco smoking status"
+    observation_coding.userSelected = False
+
+    # Code
+    observation_code = CodeableConcept.construct()
+    observation_code.coding = [observation_coding]
+    observation_code.text = "Tobacco smoking status"
+    observation.code = observation_code
+
+    # Category
+    observation_category = Coding.construct()
+    observation_category.system = OBSERVATION_CATEGORY_SYSTEM
+    observation_category.code = "social-history"
+    observation_category.display = "Social History"
+    category = CodeableConcept.construct()
+    category.coding = [observation_category]
+    observation.category = [category]
+
+    smkstat = SNOMED_LOINC_MAPPING[annotation["smokingStatus"]]
+    # valueCodeableConcept
+    value_codeable_concept = CodeableConcept()
+    value_coding = Coding.construct()
+    value_coding.system = "http://loinc.org"
+    value_coding.code = smkstat["code"]
+
+    value_coding_snomed = Coding.construct()
+    value_coding_snomed.system = "http://snomed.info/sct"
+    value_coding_snomed.code = annotation["sctid"]
+
+    value_codeable_concept.coding = [value_coding, value_coding_snomed]
+    value_codeable_concept.text = smkstat["text"]
+    observation.valueCodeableConcept = value_codeable_concept
+
+    # SNOMED concept
+    # value_codeable_concept = CodeableConcept()
+    # value_coding_snomed = Coding.construct()
+    # value_coding_snomed.system = "http://snomed.info/sct"
+    # value_coding_snomed.code = annotation["sctid"]
+    # value_codeable_concept.coding = [value_coding]
+    # value_codeable_concept.text = annotation["smokingStatus"]
+    # observation.valueCodeableConcept = value_codeable_concept
+
+    # if pack_years := annotation["packYears"] != "null":
+    # valueCodeableConcept
+    # value_quantity = QuantityType()
+    # value_quantity["value"] = pack_years
+    # value_quantity.system = "http://snomed.info/sct"
+    # value_quantity.code = "401201003"
+    # value_quantity.text = "401201003"
+    # observation.valueQuantity = value_quantity
+
+    return observation

--- a/ahd2fhir/mappers/ahd_to_observation_smkstat.py
+++ b/ahd2fhir/mappers/ahd_to_observation_smkstat.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+from typing import List
 
 from fhir.resources.codeableconcept import CodeableConcept
 from fhir.resources.coding import Coding
@@ -16,6 +17,7 @@ OBSERVATION_PROFILE = (
     + "fhir/core/StructureDefinition/Observation"
 )
 UKLFR_TYPE_SMKSTAT = "de.medunifreiburg.imbi.mds.extraction.types.Smoking"
+AHD_TYPE = UKLFR_TYPE_SMKSTAT
 
 OBSERVATION_CATEGORY_SYSTEM = (
     "http://terminology.hl7.org/CodeSystem/observation-category"
@@ -34,9 +36,9 @@ SNOMED_LOINC_MAPPING = {
 }
 
 
-def get_fhir_observation(
+def get_fhir_resources(
     ahd_response_entry, document_reference: DocumentReference
-) -> Observation:
+) -> List[Observation]:
     return get_smoking_status_observation_from_annotation(
         annotation=ahd_response_entry,
         date=document_reference.date,

--- a/ahd2fhir/utils/custom_mappers.py
+++ b/ahd2fhir/utils/custom_mappers.py
@@ -1,0 +1,12 @@
+from ahd2fhir.mappers.ahd_to_observation_smkstat import (
+    UKLFR_TYPE_SMKSTAT,
+    get_fhir_observation,
+)
+
+
+def custom_mappers(val, document_reference):
+    if val["type"] == UKLFR_TYPE_SMKSTAT:
+        smkstat_observations = get_fhir_observation(val, document_reference)
+        if smkstat_observations is not None:
+            return smkstat_observations
+    return []

--- a/ahd2fhir/utils/custom_mappers.py
+++ b/ahd2fhir/utils/custom_mappers.py
@@ -1,5 +1,9 @@
 from fhir.resources.documentreference import DocumentReference
 
+from ahd2fhir.mappers.ahd_to_observation_kidney_stone import (
+    UKLFR_TYPE_KIDNEY_STONE,
+    get_fhir_kidney_stone_observations,
+)
 from ahd2fhir.mappers.ahd_to_observation_smkstat import (
     UKLFR_TYPE_SMKSTAT,
     get_fhir_observation,
@@ -8,8 +12,16 @@ from ahd2fhir.mappers.ahd_to_observation_smkstat import (
 
 def custom_mappers(val: dict, document_reference: DocumentReference) -> list:
     results = []
+    # UKLFR Smoking Status mapper
     if val["type"] == UKLFR_TYPE_SMKSTAT:
         smkstat_observations = get_fhir_observation(val, document_reference)
         if smkstat_observations is not None:
             results.extend(smkstat_observations)
+
+    # UKLFR KidneyStone mapper
+    if val["type"] == UKLFR_TYPE_KIDNEY_STONE:
+        ks_observations = get_fhir_kidney_stone_observations(val, document_reference)
+        if ks_observations not in [None, []]:
+            results.extend(ks_observations)
+
     return results

--- a/ahd2fhir/utils/custom_mappers.py
+++ b/ahd2fhir/utils/custom_mappers.py
@@ -1,12 +1,15 @@
+from fhir.resources.documentreference import DocumentReference
+
 from ahd2fhir.mappers.ahd_to_observation_smkstat import (
     UKLFR_TYPE_SMKSTAT,
     get_fhir_observation,
 )
 
 
-def custom_mappers(val, document_reference):
+def custom_mappers(val: dict, document_reference: DocumentReference) -> list:
+    results = []
     if val["type"] == UKLFR_TYPE_SMKSTAT:
         smkstat_observations = get_fhir_observation(val, document_reference)
         if smkstat_observations is not None:
-            return smkstat_observations
-    return []
+            results.extend(smkstat_observations)
+    return results

--- a/ahd2fhir/utils/custom_mappers.py
+++ b/ahd2fhir/utils/custom_mappers.py
@@ -1,27 +1,17 @@
 from fhir.resources.documentreference import DocumentReference
 
-from ahd2fhir.mappers.ahd_to_observation_kidney_stone import (
-    UKLFR_TYPE_KIDNEY_STONE,
-    get_fhir_kidney_stone_observations,
-)
-from ahd2fhir.mappers.ahd_to_observation_smkstat import (
-    UKLFR_TYPE_SMKSTAT,
-    get_fhir_observation,
-)
+from ahd2fhir.mappers import ahd_to_observation_kidney_stone as ks
+from ahd2fhir.mappers import ahd_to_observation_smkstat as smk
+
+mapper_functions = {
+    smk.AHD_TYPE: [smk.get_fhir_resources],
+    ks.AHD_TYPE: [ks.get_fhir_resources],
+}
 
 
 def custom_mappers(val: dict, document_reference: DocumentReference) -> list:
     results = []
-    # UKLFR Smoking Status mapper
-    if val["type"] == UKLFR_TYPE_SMKSTAT:
-        smkstat_observations = get_fhir_observation(val, document_reference)
-        if smkstat_observations is not None:
-            results.extend(smkstat_observations)
-
-    # UKLFR KidneyStone mapper
-    if val["type"] == UKLFR_TYPE_KIDNEY_STONE:
-        ks_observations = get_fhir_kidney_stone_observations(val, document_reference)
-        if ks_observations not in [None, []]:
-            results.extend(ks_observations)
-
+    if (mappers := mapper_functions.get(val["type"], None)) is not None:
+        for mapper in mappers:
+            results.extend(mapper(val, document_reference))
     return results

--- a/ahd2fhir/utils/resource_handler.py
+++ b/ahd2fhir/utils/resource_handler.py
@@ -262,7 +262,6 @@ class ResourceHandler:
 
         total_results.extend(medication_resources_unique)
         total_results.extend(medication_statements_unique)
-        log.error([type(r) for r in total_results])
 
         return total_results
 

--- a/ahd2fhir/utils/resource_handler.py
+++ b/ahd2fhir/utils/resource_handler.py
@@ -21,6 +21,7 @@ from tenacity.after import after_log
 
 from ahd2fhir.mappers import ahd_to_condition, ahd_to_medication_statement
 from ahd2fhir.utils.bundle_builder import BundleBuilder
+from ahd2fhir.utils.custom_mappers import custom_mappers
 from ahd2fhir.utils.device_builder import build_device
 from ahd2fhir.utils.fhir_utils import sha256_of_identifier
 
@@ -237,6 +238,9 @@ class ResourceHandler:
                 )
                 if statement is not None:
                     medication_statement_lists.append(statement)
+
+            # if config.custom_mappers_enabled:
+            total_results.extend(custom_mappers(val, document_reference))
 
         medication_results = []
         medication_statement_results = []

--- a/ahd2fhir/utils/resource_handler.py
+++ b/ahd2fhir/utils/resource_handler.py
@@ -1,6 +1,7 @@
 import base64
 import datetime
 import logging
+import os
 import time
 from typing import List, Tuple
 
@@ -239,8 +240,9 @@ class ResourceHandler:
                 if statement is not None:
                     medication_statement_lists.append(statement)
 
-            # if config.custom_mappers_enabled:
-            total_results.extend(custom_mappers(val, document_reference))
+            # if custom_mappers_enabled
+            if os.getenv("CUSTOM_MAPPERS_ENABLED", "False").lower() in ["true", "1"]:
+                total_results.extend(custom_mappers(val, document_reference))
 
         medication_results = []
         medication_statement_results = []

--- a/tests/resources/ahd/payload_1.json
+++ b/tests/resources/ahd/payload_1.json
@@ -1621,5 +1621,62 @@
   "language": "de",
   "type": "de.averbis.types.health.DocumentAnnotation",
   "version": "5.29.0"
+ },
+{
+  "begin": 17,
+  "end": 23,
+  "type": "de.medunifreiburg.imbi.mds.extraction.types.Smoking",
+  "coveredText": "trauch",
+  "id": 2907,
+  "qualifier": {
+    "begin": 13,
+    "end": 18,
+    "type": "de.medunifreiburg.imbi.mds.extraction.types.QualifierSmokingStatus",
+    "coveredText": "nicht",
+    "id": 2917,
+    "sctid": "260385009",
+    "value": "negative",
+    "preferred": "Negative (qualifier value)"
+  },
+  "smokingStatusProbability": "1.0000100135803223",
+  "packYears": null,
+  "sctid": "160618006",
+  "smokingStatus": "CURRENT-NON-SMOKER",
+  "preferred": "Finding of tobacco smoking behavior (finding)"
+ },
+ {
+  "begin": 2,
+  "end": 8,
+  "type": "de.medunifreiburg.imbi.mds.extraction.types.Smoking",
+  "coveredText": "ikotin",
+  "id": 3469,
+  "qualifier": {
+    "begin": 8,
+    "end": 14,
+    "type": "de.medunifreiburg.imbi.mds.extraction.types.QualifierSmokingStatus",
+    "coveredText": "abusus",
+    "id": 3479,
+    "sctid": "10828004",
+    "value": "positive",
+    "preferred": "Positive (qualifier value)"
+  },
+  "smokingStatusProbability": "1.0000100135803223",
+  "packYears": "200",
+  "sctid": "77176002",
+  "smokingStatus": "CURRENT-SMOKER",
+  "preferred": "Finding of tobacco smoking behavior (finding)"
+ },
+ {
+  "begin": 21,
+  "end": 26,
+  "type": "de.medunifreiburg.imbi.mds.extraction.types.Smoking",
+  "coveredText": "Rauch",
+  "id": 4365,
+  "qualifier": null,
+  "smokingStatusProbability": "0.9998363852500916",
+  "packYears": "1234",
+  "sctid": "77176002",
+  "smokingStatus": "CURRENT-SMOKER",
+  "preferred": "Finding of tobacco smoking behavior (finding)"
  }
 ]

--- a/tests/resources/ahd/payload_1.json
+++ b/tests/resources/ahd/payload_1.json
@@ -1678,5 +1678,102 @@
   "sctid": "77176002",
   "smokingStatus": "CURRENT-SMOKER",
   "preferred": "Finding of tobacco smoking behavior (finding)"
+ },
+  {
+  "begin": 1,
+  "end": 12,
+  "type": "de.uklfr.KidneyStoneAnnotator.KidneyStoneInfo",
+  "coveredText": "Nierenstein",
+  "id": 3411,
+  "size": null,
+  "name": {
+    "begin": 1,
+    "end": 12,
+    "type": "de.uklfr.KidneyStoneAnnotator.KidneyStone",
+    "coveredText": "Nierenstein",
+    "id": 3247
+  },
+  "location": null
+ },
+ {
+  "begin": 0,
+  "end": 18,
+  "type": "de.uklfr.KidneyStoneAnnotator.KidneyStoneInfo",
+  "coveredText": "Nierenstein re 2mm",
+  "id": 4540,
+  "size": {
+    "begin": 15,
+    "end": 18,
+    "type": "de.uklfr.KidneyStoneAnnotator.Size",
+    "coveredText": "2mm",
+    "id": 4397,
+    "unit": {
+      "begin": 16,
+      "end": 18,
+      "type": "de.uklfr.KidneyStoneAnnotator.SizeUnit",
+      "coveredText": "mm",
+      "id": 4373
+    },
+    "value2": 0,
+    "value1": 2
+  }
+ },
+ {
+  "begin": 1,
+  "end": 50,
+  "type": "de.uklfr.KidneyStoneAnnotator.KidneyStoneInfo",
+  "coveredText": "Nierenstein im proximalen Ureter rechts 2,4x0,7mm",
+  "id": 7485,
+  "size": {
+    "begin": 41,
+    "end": 50,
+    "type": "de.uklfr.KidneyStoneAnnotator.Size",
+    "coveredText": "2,4x0,7mm",
+    "id": 6410,
+    "unit": {
+      "begin": 48,
+      "end": 50,
+      "type": "de.uklfr.KidneyStoneAnnotator.SizeUnit",
+      "coveredText": "mm",
+      "id": 6310
+    },
+    "value2": 0.7,
+    "value1": 2.4
+  },
+  "name": {
+    "begin": 1,
+    "end": 12,
+    "type": "de.uklfr.KidneyStoneAnnotator.KidneyStone",
+    "coveredText": "Nierenstein",
+    "id": 6086
+  },
+  "location": {
+    "begin": 16,
+    "end": 40,
+    "type": "de.uklfr.KidneyStoneAnnotator.LocationEnum",
+    "coveredText": "proximalen Ureter rechts",
+    "id": 7414,
+    "specification": {
+      "begin": 16,
+      "end": 26,
+      "type": "de.uklfr.KidneyStoneAnnotator.Specification",
+      "coveredText": "proximalen",
+      "id": 7318
+    },
+    "location": {
+      "begin": 27,
+      "end": 33,
+      "type": "de.uklfr.KidneyStoneAnnotator.Location",
+      "coveredText": "Ureter",
+      "id": 7226
+    },
+    "direction": {
+      "begin": 34,
+      "end": 40,
+      "type": "de.uklfr.KidneyStoneAnnotator.Direction",
+      "coveredText": "rechts",
+      "id": 7290
+    }
+  }
  }
 ]

--- a/tests/test_ahd_to_observation_kidney_stone.py
+++ b/tests/test_ahd_to_observation_kidney_stone.py
@@ -1,0 +1,56 @@
+import json
+
+import pytest
+
+from ahd2fhir.mappers.ahd_to_observation_kidney_stone import (
+    UKLFR_TYPE_KIDNEY_STONE,
+    get_fhir_kidney_stone_observations,
+)
+from tests.utils import get_empty_document_reference
+
+AHD_PAYLOADS_EXPECTED_NUMBER_OF_OBSERVATIONS = [
+    ("payload_1.json", 3),
+    ("payload_2.json", 0),
+]
+
+
+@pytest.mark.parametrize(
+    "ahd_json_path,expected_number_of_observations",
+    AHD_PAYLOADS_EXPECTED_NUMBER_OF_OBSERVATIONS,
+)
+def test_maps_to_expected_number_of_condition_resources(
+    ahd_json_path, expected_number_of_observations
+):
+    with open(f"tests/resources/ahd/{ahd_json_path}") as file:
+        ahd_payload = json.load(file)
+
+    observations = []
+    for val in ahd_payload:
+        if val["type"] == UKLFR_TYPE_KIDNEY_STONE:
+            mapped_observation = get_fhir_kidney_stone_observations(
+                val, get_empty_document_reference()
+            )
+            if mapped_observation is not None:
+                observations.append(mapped_observation)
+    assert len(observations) == expected_number_of_observations
+
+
+@pytest.mark.parametrize(
+    "ahd_json_path,_",
+    AHD_PAYLOADS_EXPECTED_NUMBER_OF_OBSERVATIONS,
+)
+def test_mapped_observation_coding_should_set_userselected_to_false(ahd_json_path, _):
+    with open(f"tests/resources/ahd/{ahd_json_path}") as file:
+        ahd_payload = json.load(file)
+
+    observations = []
+    for val in ahd_payload:
+        if val["type"] == UKLFR_TYPE_KIDNEY_STONE:
+            mapped_observation = get_fhir_kidney_stone_observations(
+                val, get_empty_document_reference()
+            )
+            if mapped_observation is not None:
+                observations.append(mapped_observation)
+
+    for c in observations:
+        assert all(coding.userSelected is False for coding in c[0].code.coding)

--- a/tests/test_ahd_to_observation_kidney_stone.py
+++ b/tests/test_ahd_to_observation_kidney_stone.py
@@ -4,7 +4,7 @@ import pytest
 
 from ahd2fhir.mappers.ahd_to_observation_kidney_stone import (
     UKLFR_TYPE_KIDNEY_STONE,
-    get_fhir_kidney_stone_observations,
+    get_fhir_resources,
 )
 from tests.utils import get_empty_document_reference
 
@@ -27,9 +27,7 @@ def test_maps_to_expected_number_of_condition_resources(
     observations = []
     for val in ahd_payload:
         if val["type"] == UKLFR_TYPE_KIDNEY_STONE:
-            mapped_observation = get_fhir_kidney_stone_observations(
-                val, get_empty_document_reference()
-            )
+            mapped_observation = get_fhir_resources(val, get_empty_document_reference())
             if mapped_observation is not None:
                 observations.append(mapped_observation)
     assert len(observations) == expected_number_of_observations
@@ -46,9 +44,7 @@ def test_mapped_observation_coding_should_set_userselected_to_false(ahd_json_pat
     observations = []
     for val in ahd_payload:
         if val["type"] == UKLFR_TYPE_KIDNEY_STONE:
-            mapped_observation = get_fhir_kidney_stone_observations(
-                val, get_empty_document_reference()
-            )
+            mapped_observation = get_fhir_resources(val, get_empty_document_reference())
             if mapped_observation is not None:
                 observations.append(mapped_observation)
 

--- a/tests/test_ahd_to_observation_kidney_stone.py
+++ b/tests/test_ahd_to_observation_kidney_stone.py
@@ -29,5 +29,5 @@ def test_maps_to_expected_number_of_condition_resources(
 )
 def test_mapped_observation_coding_should_set_userselected_to_false(ahd_json_path, _):
     observations = map_resources(ahd_json_path, AHD_TYPE, get_fhir_resources)
-    for c in observations:
-        assert all(coding.userSelected is False for coding in c[0].code.coding)
+    for o in observations:
+        assert all(coding.userSelected is False for coding in o[0].code.coding)

--- a/tests/test_ahd_to_observation_kidney_stone.py
+++ b/tests/test_ahd_to_observation_kidney_stone.py
@@ -1,12 +1,10 @@
-import json
-
 import pytest
 
 from ahd2fhir.mappers.ahd_to_observation_kidney_stone import (
-    UKLFR_TYPE_KIDNEY_STONE,
+    AHD_TYPE,
     get_fhir_resources,
 )
-from tests.utils import get_empty_document_reference
+from tests.utils import map_resources
 
 AHD_PAYLOADS_EXPECTED_NUMBER_OF_OBSERVATIONS = [
     ("payload_1.json", 3),
@@ -21,15 +19,7 @@ AHD_PAYLOADS_EXPECTED_NUMBER_OF_OBSERVATIONS = [
 def test_maps_to_expected_number_of_condition_resources(
     ahd_json_path, expected_number_of_observations
 ):
-    with open(f"tests/resources/ahd/{ahd_json_path}") as file:
-        ahd_payload = json.load(file)
-
-    observations = []
-    for val in ahd_payload:
-        if val["type"] == UKLFR_TYPE_KIDNEY_STONE:
-            mapped_observation = get_fhir_resources(val, get_empty_document_reference())
-            if mapped_observation is not None:
-                observations.append(mapped_observation)
+    observations = map_resources(ahd_json_path, AHD_TYPE, get_fhir_resources)
     assert len(observations) == expected_number_of_observations
 
 
@@ -38,15 +28,6 @@ def test_maps_to_expected_number_of_condition_resources(
     AHD_PAYLOADS_EXPECTED_NUMBER_OF_OBSERVATIONS,
 )
 def test_mapped_observation_coding_should_set_userselected_to_false(ahd_json_path, _):
-    with open(f"tests/resources/ahd/{ahd_json_path}") as file:
-        ahd_payload = json.load(file)
-
-    observations = []
-    for val in ahd_payload:
-        if val["type"] == UKLFR_TYPE_KIDNEY_STONE:
-            mapped_observation = get_fhir_resources(val, get_empty_document_reference())
-            if mapped_observation is not None:
-                observations.append(mapped_observation)
-
+    observations = map_resources(ahd_json_path, AHD_TYPE, get_fhir_resources)
     for c in observations:
         assert all(coding.userSelected is False for coding in c[0].code.coding)

--- a/tests/test_ahd_to_observation_smkstat.py
+++ b/tests/test_ahd_to_observation_smkstat.py
@@ -1,0 +1,83 @@
+import json
+
+import pytest
+
+from ahd2fhir.config import Settings
+from ahd2fhir.mappers.ahd_to_observation_smkstat import (
+    UKLFR_TYPE_SMKSTAT,
+    get_fhir_observation,
+)
+from tests.utils import get_empty_document_reference
+
+AHD_PAYLOADS_EXPECTED_NUMBER_OF_CONDITIONS = [
+    ("payload_1.json", 3),
+    ("payload_2.json", 0),
+]
+
+
+def get_settings_override():
+    return Settings(
+        ahd_url="localhost",
+        ahd_api_token="test",
+        ahd_project="test",
+        ahd_pipeline="test",
+    )
+
+
+@pytest.mark.parametrize(
+    "ahd_json_path,expected_number_of_conditions",
+    AHD_PAYLOADS_EXPECTED_NUMBER_OF_CONDITIONS,
+)
+def test_maps_to_expected_number_of_condition_resources(
+    ahd_json_path, expected_number_of_conditions
+):
+
+    with open(f"tests/resources/ahd/{ahd_json_path}") as file:
+        ahd_payload = json.load(file)
+
+    conditions = []
+    for val in ahd_payload:
+        if val["type"] == UKLFR_TYPE_SMKSTAT:
+            mapped_condition = get_fhir_observation(val, get_empty_document_reference())
+            if mapped_condition is not None:
+                conditions.append(mapped_condition)
+    assert len(conditions) == expected_number_of_conditions
+
+
+@pytest.mark.parametrize(
+    "ahd_json_path,_",
+    AHD_PAYLOADS_EXPECTED_NUMBER_OF_CONDITIONS,
+)
+def test_mapped_condition_coding_should_set_userselected_to_false(ahd_json_path, _):
+    with open(f"tests/resources/ahd/{ahd_json_path}") as file:
+        ahd_payload = json.load(file)
+
+    conditions = []
+    for val in ahd_payload:
+        if val["type"] == UKLFR_TYPE_SMKSTAT:
+            mapped_condition = get_fhir_observation(val, get_empty_document_reference())
+            if mapped_condition is not None:
+                conditions.append(mapped_condition)
+
+    for c in conditions:
+        assert all(coding.userSelected is False for coding in c.code.coding)
+
+
+@pytest.mark.parametrize(
+    "ahd_json_path,_",
+    AHD_PAYLOADS_EXPECTED_NUMBER_OF_CONDITIONS,
+)
+def test_mapped_condition_coding_includes_snomed_and_loin(ahd_json_path, _):
+    with open(f"tests/resources/ahd/{ahd_json_path}") as file:
+        ahd_payload = json.load(file)
+
+    conditions = []
+    for val in ahd_payload:
+        if val["type"] == UKLFR_TYPE_SMKSTAT:
+            mapped_condition = get_fhir_observation(val, get_empty_document_reference())
+            if mapped_condition is not None:
+                conditions.append(mapped_condition)
+
+    for c in conditions:
+        assert c.valueCodeableConcept.coding[0].system == "http://loinc.org"
+        assert c.valueCodeableConcept.coding[1].system == "http://snomed.info/sct"

--- a/tests/test_ahd_to_observation_smkstat.py
+++ b/tests/test_ahd_to_observation_smkstat.py
@@ -1,12 +1,7 @@
-import json
-
 import pytest
 
-from ahd2fhir.mappers.ahd_to_observation_smkstat import (
-    UKLFR_TYPE_SMKSTAT,
-    get_fhir_resources,
-)
-from tests.utils import get_empty_document_reference
+from ahd2fhir.mappers.ahd_to_observation_smkstat import AHD_TYPE, get_fhir_resources
+from tests.utils import map_resources
 
 AHD_PAYLOADS_EXPECTED_NUMBER_OF_CONDITIONS = [
     ("payload_1.json", 3),
@@ -22,16 +17,8 @@ def test_maps_to_expected_number_of_condition_resources(
     ahd_json_path, expected_number_of_conditions
 ):
 
-    with open(f"tests/resources/ahd/{ahd_json_path}") as file:
-        ahd_payload = json.load(file)
-
-    conditions = []
-    for val in ahd_payload:
-        if val["type"] == UKLFR_TYPE_SMKSTAT:
-            mapped_condition = get_fhir_resources(val, get_empty_document_reference())
-            if mapped_condition is not None:
-                conditions.append(mapped_condition)
-    assert len(conditions) == expected_number_of_conditions
+    observations = map_resources(ahd_json_path, AHD_TYPE, get_fhir_resources)
+    assert len(observations) == expected_number_of_conditions
 
 
 @pytest.mark.parametrize(
@@ -39,18 +26,9 @@ def test_maps_to_expected_number_of_condition_resources(
     AHD_PAYLOADS_EXPECTED_NUMBER_OF_CONDITIONS,
 )
 def test_mapped_condition_coding_should_set_userselected_to_false(ahd_json_path, _):
-    with open(f"tests/resources/ahd/{ahd_json_path}") as file:
-        ahd_payload = json.load(file)
-
-    conditions = []
-    for val in ahd_payload:
-        if val["type"] == UKLFR_TYPE_SMKSTAT:
-            mapped_condition = get_fhir_resources(val, get_empty_document_reference())
-            if mapped_condition is not None:
-                conditions.append(mapped_condition)
-
-    for c in conditions:
-        assert all(coding.userSelected is False for coding in c.code.coding)
+    observations = map_resources(ahd_json_path, AHD_TYPE, get_fhir_resources)
+    for o in observations:
+        assert all(coding.userSelected is False for coding in o.code.coding)
 
 
 @pytest.mark.parametrize(
@@ -58,16 +36,8 @@ def test_mapped_condition_coding_should_set_userselected_to_false(ahd_json_path,
     AHD_PAYLOADS_EXPECTED_NUMBER_OF_CONDITIONS,
 )
 def test_mapped_condition_coding_includes_snomed_and_loin(ahd_json_path, _):
-    with open(f"tests/resources/ahd/{ahd_json_path}") as file:
-        ahd_payload = json.load(file)
+    observations = map_resources(ahd_json_path, AHD_TYPE, get_fhir_resources)
 
-    conditions = []
-    for val in ahd_payload:
-        if val["type"] == UKLFR_TYPE_SMKSTAT:
-            mapped_condition = get_fhir_resources(val, get_empty_document_reference())
-            if mapped_condition is not None:
-                conditions.append(mapped_condition)
-
-    for c in conditions:
-        assert c.valueCodeableConcept.coding[0].system == "http://loinc.org"
-        assert c.valueCodeableConcept.coding[1].system == "http://snomed.info/sct"
+    for o in observations:
+        assert o.valueCodeableConcept.coding[0].system == "http://loinc.org"
+        assert o.valueCodeableConcept.coding[1].system == "http://snomed.info/sct"

--- a/tests/test_ahd_to_observation_smkstat.py
+++ b/tests/test_ahd_to_observation_smkstat.py
@@ -2,7 +2,6 @@ import json
 
 import pytest
 
-from ahd2fhir.config import Settings
 from ahd2fhir.mappers.ahd_to_observation_smkstat import (
     UKLFR_TYPE_SMKSTAT,
     get_fhir_observation,
@@ -13,15 +12,6 @@ AHD_PAYLOADS_EXPECTED_NUMBER_OF_CONDITIONS = [
     ("payload_1.json", 3),
     ("payload_2.json", 0),
 ]
-
-
-def get_settings_override():
-    return Settings(
-        ahd_url="localhost",
-        ahd_api_token="test",
-        ahd_project="test",
-        ahd_pipeline="test",
-    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ahd_to_observation_smkstat.py
+++ b/tests/test_ahd_to_observation_smkstat.py
@@ -4,7 +4,7 @@ import pytest
 
 from ahd2fhir.mappers.ahd_to_observation_smkstat import (
     UKLFR_TYPE_SMKSTAT,
-    get_fhir_observation,
+    get_fhir_resources,
 )
 from tests.utils import get_empty_document_reference
 
@@ -28,7 +28,7 @@ def test_maps_to_expected_number_of_condition_resources(
     conditions = []
     for val in ahd_payload:
         if val["type"] == UKLFR_TYPE_SMKSTAT:
-            mapped_condition = get_fhir_observation(val, get_empty_document_reference())
+            mapped_condition = get_fhir_resources(val, get_empty_document_reference())
             if mapped_condition is not None:
                 conditions.append(mapped_condition)
     assert len(conditions) == expected_number_of_conditions
@@ -45,7 +45,7 @@ def test_mapped_condition_coding_should_set_userselected_to_false(ahd_json_path,
     conditions = []
     for val in ahd_payload:
         if val["type"] == UKLFR_TYPE_SMKSTAT:
-            mapped_condition = get_fhir_observation(val, get_empty_document_reference())
+            mapped_condition = get_fhir_resources(val, get_empty_document_reference())
             if mapped_condition is not None:
                 conditions.append(mapped_condition)
 
@@ -64,7 +64,7 @@ def test_mapped_condition_coding_includes_snomed_and_loin(ahd_json_path, _):
     conditions = []
     for val in ahd_payload:
         if val["type"] == UKLFR_TYPE_SMKSTAT:
-            mapped_condition = get_fhir_observation(val, get_empty_document_reference())
+            mapped_condition = get_fhir_resources(val, get_empty_document_reference())
             if mapped_condition is not None:
                 conditions.append(mapped_condition)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,6 +34,7 @@ def get_resource_handler():
 
 main.app.dependency_overrides[main.get_settings] = get_settings_override
 main.app.dependency_overrides[main.get_resource_handler] = get_resource_handler
+main.app.dependency_overrides[main.get_resource_handler] = get_resource_handler
 
 client = TestClient(main.app)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,7 +34,6 @@ def get_resource_handler():
 
 main.app.dependency_overrides[main.get_settings] = get_settings_override
 main.app.dependency_overrides[main.get_resource_handler] = get_resource_handler
-main.app.dependency_overrides[main.get_resource_handler] = get_resource_handler
 
 client = TestClient(main.app)
 

--- a/tests/test_resource_handler.py
+++ b/tests/test_resource_handler.py
@@ -18,10 +18,10 @@ class MockPipeline:
         else:
             self.response = response
 
-    def analyse_text(self, text: str, language: str):
+    def analyse_text(self, text: str, language: str, annotation_types: list):
         return self.response
 
-    def analyse_html(self, text: str, language: str):
+    def analyse_html(self, text: str, language: str, annotation_types: list):
         return self.response
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,5 +30,5 @@ def map_resources(ahd_json_path: str, ahd_type: str, func: Callable) -> list:
         if val["type"] == ahd_type:
             resource = func(val, get_empty_document_reference())
             if resource is not None:
-                resources.append(resources)
+                resources.append(resource)
     return resources

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,6 @@
+import json
+from typing import Callable
+
 from fhir.resources.attachment import Attachment
 from fhir.resources.documentreference import DocumentReference, DocumentReferenceContent
 from fhir.resources.reference import Reference
@@ -16,3 +19,16 @@ def get_empty_document_reference():
     docref.id = "empty-document"
 
     return docref
+
+
+def map_resources(ahd_json_path: str, ahd_type: str, func: Callable) -> list:
+    with open(f"tests/resources/ahd/{ahd_json_path}") as file:
+        ahd_payload = json.load(file)
+
+    resources = []
+    for val in ahd_payload:
+        if val["type"] == ahd_type:
+            resource = func(val, get_empty_document_reference())
+            if resource is not None:
+                resources.append(resources)
+    return resources


### PR DESCRIPTION
To enable the usage of custom mappers i would like to propose a [hook](https://github.com/miracum/ahd2fhir/compare/master...uklft:uklfr-annotators?expand=1#diff-b6a2a7e6bccf573109ba3c9a6da20d2bec30463d64d3eb9c646973931f96436eR244) in the main loop of `_process_documentreference` that calls user-defined functions on the current `averbis_result`.

To add the least possible amount of code to the core logic i created the file [`custom_mappers.py`](https://github.com/miracum/ahd2fhir/compare/master...uklft:uklfr-annotators?expand=1#diff-2dee9a8c494f951d599557079245f09d8ee182d37e6466162ff0bb2b8bead586) that holds a dictionary of averbis types and mapper functions to be called on the corresponding averbis annotation.
This would also allow to modularize the existing mappers.

Also this PR includes mappings for custom types (smoking status, kidneystones).

If this is an acceptible way to include custom mappers i am happy to further enhance this approach :)