### PR TITLE
feat: Add custom mapper hook and uklfr examples

### DIFF
--- a/ahd2fhir/mappers/ahd_to_observation_kidney_stone.py
+++ b/ahd2fhir/mappers/ahd_to_observation_kidney_stone.py
@@ -1,0 +1,176 @@
+import datetime
+import uuid
+from typing import List
+
+from fhir.resources.codeableconcept import CodeableConcept
+from fhir.resources.coding import Coding
+from fhir.resources.documentreference import DocumentReference
+from fhir.resources.fhirtypes import DateTime, QuantityType, ReferenceType
+from fhir.resources.meta import Meta
+from fhir.resources.observation import Observation
+from structlog import get_logger
+
+log = get_logger()
+
+CLINICAL_STATUS_MAPPING = {"ACTIVE": "active", "RESOLVED": "resolved"}
+SIDE_MAPPING = {
+    "LEFT": ("7771000", "Left"),
+    "RIGHT": ("24028007", "Right"),
+    "BOTH": ("51440002", "Right and left"),
+}
+
+UNIT_MAPPING = {"cm": "258672001", "mm": "258673006"}
+
+OBSERVATION_PROFILE = (
+    "https://www.medizininformatik-initiative.de/"
+    + "fhir/core/StructureDefinition/Observation"
+)
+UKLFR_TYPE_KIDNEY_STONE = "de.uklfr.KidneyStoneAnnotator.KidneyStoneInfo"
+AHD_TYPE = UKLFR_TYPE_KIDNEY_STONE
+
+OBSERVATION_CATEGORY_SYSTEM = (
+    "http://terminology.hl7.org/CodeSystem/observation-category"
+)
+
+STONE_DIMENSION_MAP = {
+    "width": {
+        "code": "9805-3",
+        "name": "Width of Stone",
+        "display": "Width (Stone) [Length]",
+    },
+    "length": {
+        "code": "9799-8",
+        "name": "Length of Stone",
+        "display": "Length (Stone) [Length]",
+    },
+}
+
+
+def get_fhir_resources(
+    ahd_response_entry, document_reference: DocumentReference
+) -> List[Observation]:
+    return get_kidney_stone_from_annotation(
+        annotation=ahd_response_entry,
+        date=document_reference.date,
+        doc_ref=document_reference,
+    )
+
+
+def fhirdate_now() -> DateTime:
+    return DateTime.validate(datetime.datetime.now(datetime.timezone.utc))
+
+
+def get_kidney_stone_from_annotation(
+    annotation, date, doc_ref: DocumentReference
+) -> List[Observation]:
+    # Observation details
+    observation = Observation.construct()
+    observation.status = "final"
+    observation.meta = Meta.construct()
+    observation.meta.profile = [OBSERVATION_PROFILE]
+    observation.subject = doc_ref.subject
+    observation.effectiveDateTime = date or fhirdate_now()
+    observation.id = str(uuid.uuid4())
+
+    # Coding + Code
+    observation_coding = Coding.construct()
+    observation_coding.system = "http://snomed.info/sct"
+    observation_coding.code = "95570007"
+    observation_coding.display = "Kidney stone (disorder)"
+    observation_coding.userSelected = False
+    observation_code = CodeableConcept.construct()
+    observation_code.coding = [observation_coding]
+    observation_code.text = "Kidney stone"
+    observation.code = observation_code
+
+    # Category
+    observation_category = Coding.construct()
+    observation_category.system = OBSERVATION_CATEGORY_SYSTEM
+    observation_category.code = "imaging"
+    observation_category.display = "Imaging"
+    category = CodeableConcept.construct()
+    category.coding = [observation_category]
+    observation.category = [category]
+
+    # Method
+    observation_method = Coding.construct()
+    observation_method.system = "http://snomed.info/sct"
+    observation_method.code = "363680008"
+    observation_method.display = " Radiographic imaging procedure"
+    method = CodeableConcept.construct()
+    method.coding = [observation_method]
+    observation.method = method
+
+    # valueCodeableConcept
+    value_codeable_concept = CodeableConcept()
+    value_coding = Coding.construct()
+    value_coding.system = "http://snomed.info/sct"
+    value_coding.code = "56381008"
+    value_codeable_concept.coding = [value_coding]
+    value_codeable_concept.text = "Calculus (morphologic abnormality)"
+    observation.valueCodeableConcept = value_codeable_concept
+
+    observations = [observation]
+
+    # Create Observation for each Dimension (X/Y)
+    if (stone_size := annotation["size"]) is not None:
+        observation.hasMember = []
+        stone_unit = stone_size["unit"]["coveredText"]
+        stone_len = stone_size["value1"]
+        stone_len_obs = stone_dimension_observation(
+            observation, "length", stone_len, unit=stone_unit
+        )
+        observation.hasMember.append(stone_len_obs[1])
+        observations.append(stone_len_obs[0])
+
+        stone_width = stone_size["value2"]
+        if stone_width in [0, "0"]:
+            stone_width = stone_len
+        stone_width_obs = stone_dimension_observation(
+            observation, "width", stone_width, unit=stone_unit
+        )
+        observation.hasMember.append(stone_width_obs[1])
+        observations.append(stone_width_obs[0])
+
+    return observations
+
+
+def stone_dimension_observation(
+    parent: Observation, dimension: str, value: float, unit: str
+):
+    dimension_type = STONE_DIMENSION_MAP[dimension]
+    # Observation details
+    observation = Observation.construct()
+    observation.status = "final"
+    observation.meta = Meta.construct()
+    observation.meta.profile = [OBSERVATION_PROFILE]
+    observation.subject = parent.subject
+    observation.effectiveDateTime = parent.effectiveDateTime
+    observation.id = str(uuid.uuid4())
+
+    # Coding
+    observation_coding = Coding.construct()
+    observation_coding.system = "http://loinc.org"
+    observation_coding.code = dimension_type["code"]
+    observation_coding.display = dimension_type["display"]
+    observation_coding.userSelected = False
+    # Code
+    observation_code = CodeableConcept.construct()
+    observation_code.coding = [observation_coding]
+    observation_code.text = dimension_type["name"]
+    observation.code = observation_code
+
+    # valueCodeableConcept
+    value_quantity = QuantityType()
+    value_quantity["system"] = "http://unitsofmeasure.org"
+    value_quantity["code"] = unit
+    value_quantity["value"] = value
+    value_quantity["unit"] = {"mm": "Millimeter", "cm": "Centimeter"}[unit]
+    observation.valueQuantity = value_quantity
+
+    # Create Reference to Observation
+    observation_reference = ReferenceType()
+    observation_reference["reference"] = f"Observation/{observation.id}"
+    observation_reference["display"] = observation.code.coding[0].display
+
+    return observation, observation_reference

--- a/ahd2fhir/mappers/ahd_to_observation_smkstat.py
+++ b/ahd2fhir/mappers/ahd_to_observation_smkstat.py
@@ -1,0 +1,120 @@
+import datetime
+import uuid
+from typing import List
+
+from fhir.resources.codeableconcept import CodeableConcept
+from fhir.resources.coding import Coding
+from fhir.resources.documentreference import DocumentReference
+from fhir.resources.fhirtypes import DateTime
+from fhir.resources.meta import Meta
+from fhir.resources.observation import Observation
+from structlog import get_logger
+
+log = get_logger()
+
+OBSERVATION_PROFILE = (
+    "https://www.medizininformatik-initiative.de/"
+    + "fhir/core/StructureDefinition/Observation"
+)
+UKLFR_TYPE_SMKSTAT = "de.medunifreiburg.imbi.mds.extraction.types.Smoking"
+AHD_TYPE = UKLFR_TYPE_SMKSTAT
+
+OBSERVATION_CATEGORY_SYSTEM = (
+    "http://terminology.hl7.org/CodeSystem/observation-category"
+)
+
+SNOMED_LOINC_MAPPING = {
+    "PAST-SMOKER": {"code": "LA15920-4", "text": "Former smoker"},
+    "CURRENT-SMOKER": {"code": "LA18976-3", "text": "Current every day smoker"},
+    "CURRENT-NON-SMOKER": {"code": "LA15920-4", "text": "Former smoker"},
+    "NEVER-SMOKER": {"code": "LA18978-9", "text": "Never smoker"},
+    "CURRENT-OR-PAST-SMOKER": {
+        "code": "LA18979-7",
+        "text": "Smoker, current status unknown",
+    },
+    "UNKNOW": {"code": "LA18980-5", "text": "Unknown if ever smoked"},
+}
+
+
+def get_fhir_resources(
+    ahd_response_entry, document_reference: DocumentReference
+) -> List[Observation]:
+    return get_smoking_status_observation_from_annotation(
+        annotation=ahd_response_entry,
+        date=document_reference.date,
+        doc_ref=document_reference,
+    )
+
+
+def fhirdate_now():
+    return DateTime.validate(datetime.datetime.now(datetime.timezone.utc))
+
+
+def get_smoking_status_observation_from_annotation(
+    annotation, date, doc_ref: DocumentReference
+):
+    # Observation details
+    observation = Observation.construct()
+    observation.status = "final"
+    observation.meta = Meta.construct()
+    observation.meta.profile = [OBSERVATION_PROFILE]
+    observation.subject = doc_ref.subject
+    observation.effectiveDateTime = date or fhirdate_now()
+    observation.id = str(uuid.uuid4())
+
+    # Coding
+    observation_coding = Coding.construct()
+    observation_coding.system = "http://loinc.org"
+    observation_coding.code = "72166-2"
+    observation_coding.display = "Tobacco smoking status"
+    observation_coding.userSelected = False
+
+    # Code
+    observation_code = CodeableConcept.construct()
+    observation_code.coding = [observation_coding]
+    observation_code.text = "Tobacco smoking status"
+    observation.code = observation_code
+
+    # Category
+    observation_category = Coding.construct()
+    observation_category.system = OBSERVATION_CATEGORY_SYSTEM
+    observation_category.code = "social-history"
+    observation_category.display = "Social History"
+    category = CodeableConcept.construct()
+    category.coding = [observation_category]
+    observation.category = [category]
+
+    smkstat = SNOMED_LOINC_MAPPING[annotation["smokingStatus"]]
+    # valueCodeableConcept
+    value_codeable_concept = CodeableConcept()
+    value_coding = Coding.construct()
+    value_coding.system = "http://loinc.org"
+    value_coding.code = smkstat["code"]
+
+    value_coding_snomed = Coding.construct()
+    value_coding_snomed.system = "http://snomed.info/sct"
+    value_coding_snomed.code = annotation["sctid"]
+
+    value_codeable_concept.coding = [value_coding, value_coding_snomed]
+    value_codeable_concept.text = smkstat["text"]
+    observation.valueCodeableConcept = value_codeable_concept
+
+    # SNOMED concept
+    # value_codeable_concept = CodeableConcept()
+    # value_coding_snomed = Coding.construct()
+    # value_coding_snomed.system = "http://snomed.info/sct"
+    # value_coding_snomed.code = annotation["sctid"]
+    # value_codeable_concept.coding = [value_coding]
+    # value_codeable_concept.text = annotation["smokingStatus"]
+    # observation.valueCodeableConcept = value_codeable_concept
+
+    # if pack_years := annotation["packYears"] != "null":
+    # valueCodeableConcept
+    # value_quantity = QuantityType()
+    # value_quantity["value"] = pack_years
+    # value_quantity.system = "http://snomed.info/sct"
+    # value_quantity.code = "401201003"
+    # value_quantity.text = "401201003"
+    # observation.valueQuantity = value_quantity
+
+    return observation

--- a/ahd2fhir/utils/custom_mappers.py
+++ b/ahd2fhir/utils/custom_mappers.py
@@ -1,0 +1,17 @@
+from fhir.resources.documentreference import DocumentReference
+
+from ahd2fhir.mappers import ahd_to_observation_kidney_stone as ks
+from ahd2fhir.mappers import ahd_to_observation_smkstat as smk
+
+mapper_functions = {
+    smk.AHD_TYPE: [smk.get_fhir_resources],
+    ks.AHD_TYPE: [ks.get_fhir_resources],
+}
+
+
+def custom_mappers(val: dict, document_reference: DocumentReference) -> list:
+    results = []
+    if (mappers := mapper_functions.get(val["type"], None)) is not None:
+        for mapper in mappers:
+            results.extend(mapper(val, document_reference))
+    return results

--- a/ahd2fhir/utils/resource_handler.py
+++ b/ahd2fhir/utils/resource_handler.py
@@ -1,8 +1,8 @@
 import base64
 import datetime
 import logging
-import time
 import os
+import time
 from typing import List, Tuple
 
 import structlog
@@ -22,8 +22,8 @@ from tenacity.after import after_log
 
 from ahd2fhir.mappers import ahd_to_condition, ahd_to_medication_statement
 from ahd2fhir.utils.bundle_builder import BundleBuilder
-from ahd2fhir.utils.device_builder import build_device
 from ahd2fhir.utils.custom_mappers import custom_mappers, mapper_functions
+from ahd2fhir.utils.device_builder import build_device
 from ahd2fhir.utils.fhir_utils import sha256_of_identifier
 
 MAPPING_FAILURES_COUNTER = Counter("mapping_failures", "Exceptions during mapping")

--- a/ahd2fhir/utils/resource_handler.py
+++ b/ahd2fhir/utils/resource_handler.py
@@ -2,6 +2,7 @@ import base64
 import datetime
 import logging
 import time
+import os
 from typing import List, Tuple
 
 import structlog
@@ -22,6 +23,7 @@ from tenacity.after import after_log
 from ahd2fhir.mappers import ahd_to_condition, ahd_to_medication_statement
 from ahd2fhir.utils.bundle_builder import BundleBuilder
 from ahd2fhir.utils.device_builder import build_device
+from ahd2fhir.utils.custom_mappers import custom_mappers, mapper_functions
 from ahd2fhir.utils.fhir_utils import sha256_of_identifier
 
 MAPPING_FAILURES_COUNTER = Counter("mapping_failures", "Exceptions during mapping")
@@ -237,6 +239,10 @@ class ResourceHandler:
                 )
                 if statement is not None:
                     medication_statement_lists.append(statement)
+
+            # if custom_mappers_enabled
+            if os.getenv("CUSTOM_MAPPERS_ENABLED", "False").lower() in ["true", "1"]:
+                total_results.extend(custom_mappers(val, document_reference))
 
         medication_results = []
         medication_statement_results = []

--- a/ahd2fhir/utils/resource_handler.py
+++ b/ahd2fhir/utils/resource_handler.py
@@ -305,10 +305,22 @@ class ResourceHandler:
     def _perform_text_analysis(
         self, text: str, mime_type: str = "text/plain", lang: str = None
     ):
+        types = ",".join(
+            [
+                AHD_TYPE_DIAGNOSIS,
+                AHD_TYPE_MEDICATION,
+                AHD_TYPE_DOCUMENT_ANNOTATION,
+                *mapper_functions.keys(),
+            ]
+        )
         if mime_type == "text/html":
-            return self.pipeline.analyse_html(text, language=lang)
+            return self.pipeline.analyse_html(
+                text, language=lang, annotation_types=types
+            )
         else:
-            return self.pipeline.analyse_text(text, language=lang)
+            return self.pipeline.analyse_text(
+                text, language=lang, annotation_types=types
+            )
 
     def _build_composition_identifier_from_documentreference(
         self,

--- a/tests/resources/ahd/payload_1.json
+++ b/tests/resources/ahd/payload_1.json
@@ -1621,5 +1621,159 @@
   "language": "de",
   "type": "de.averbis.types.health.DocumentAnnotation",
   "version": "5.29.0"
+ },
+ {
+  "begin": 17,
+  "end": 23,
+  "type": "de.medunifreiburg.imbi.mds.extraction.types.Smoking",
+  "coveredText": "trauch",
+  "id": 2907,
+  "qualifier": {
+   "begin": 13,
+   "end": 18,
+   "type": "de.medunifreiburg.imbi.mds.extraction.types.QualifierSmokingStatus",
+   "coveredText": "nicht",
+   "id": 2917,
+   "sctid": "260385009",
+   "value": "negative",
+   "preferred": "Negative (qualifier value)"
+  },
+  "smokingStatusProbability": "1.0000100135803223",
+  "packYears": null,
+  "sctid": "160618006",
+  "smokingStatus": "CURRENT-NON-SMOKER",
+  "preferred": "Finding of tobacco smoking behavior (finding)"
+ },
+ {
+  "begin": 2,
+  "end": 8,
+  "type": "de.medunifreiburg.imbi.mds.extraction.types.Smoking",
+  "coveredText": "ikotin",
+  "id": 3469,
+  "qualifier": {
+   "begin": 8,
+   "end": 14,
+   "type": "de.medunifreiburg.imbi.mds.extraction.types.QualifierSmokingStatus",
+   "coveredText": "abusus",
+   "id": 3479,
+   "sctid": "10828004",
+   "value": "positive",
+   "preferred": "Positive (qualifier value)"
+  },
+  "smokingStatusProbability": "1.0000100135803223",
+  "packYears": "200",
+  "sctid": "77176002",
+  "smokingStatus": "CURRENT-SMOKER",
+  "preferred": "Finding of tobacco smoking behavior (finding)"
+ },
+ {
+  "begin": 21,
+  "end": 26,
+  "type": "de.medunifreiburg.imbi.mds.extraction.types.Smoking",
+  "coveredText": "Rauch",
+  "id": 4365,
+  "qualifier": null,
+  "smokingStatusProbability": "0.9998363852500916",
+  "packYears": "1234",
+  "sctid": "77176002",
+  "smokingStatus": "CURRENT-SMOKER",
+  "preferred": "Finding of tobacco smoking behavior (finding)"
+ },
+ {
+  "begin": 1,
+  "end": 12,
+  "type": "de.uklfr.KidneyStoneAnnotator.KidneyStoneInfo",
+  "coveredText": "Nierenstein",
+  "id": 3411,
+  "size": null,
+  "name": {
+   "begin": 1,
+   "end": 12,
+   "type": "de.uklfr.KidneyStoneAnnotator.KidneyStone",
+   "coveredText": "Nierenstein",
+   "id": 3247
+  },
+  "location": null
+ },
+ {
+  "begin": 0,
+  "end": 18,
+  "type": "de.uklfr.KidneyStoneAnnotator.KidneyStoneInfo",
+  "coveredText": "Nierenstein re 2mm",
+  "id": 4540,
+  "size": {
+   "begin": 15,
+   "end": 18,
+   "type": "de.uklfr.KidneyStoneAnnotator.Size",
+   "coveredText": "2mm",
+   "id": 4397,
+   "unit": {
+    "begin": 16,
+    "end": 18,
+    "type": "de.uklfr.KidneyStoneAnnotator.SizeUnit",
+    "coveredText": "mm",
+    "id": 4373
+   },
+   "value2": 0,
+   "value1": 2
+  }
+ },
+ {
+  "begin": 1,
+  "end": 50,
+  "type": "de.uklfr.KidneyStoneAnnotator.KidneyStoneInfo",
+  "coveredText": "Nierenstein im proximalen Ureter rechts 2,4x0,7mm",
+  "id": 7485,
+  "size": {
+   "begin": 41,
+   "end": 50,
+   "type": "de.uklfr.KidneyStoneAnnotator.Size",
+   "coveredText": "2,4x0,7mm",
+   "id": 6410,
+   "unit": {
+    "begin": 48,
+    "end": 50,
+    "type": "de.uklfr.KidneyStoneAnnotator.SizeUnit",
+    "coveredText": "mm",
+    "id": 6310
+   },
+   "value2": 0.7,
+   "value1": 2.4
+  },
+  "name": {
+   "begin": 1,
+   "end": 12,
+   "type": "de.uklfr.KidneyStoneAnnotator.KidneyStone",
+   "coveredText": "Nierenstein",
+   "id": 6086
+  },
+  "location": {
+   "begin": 16,
+   "end": 40,
+   "type": "de.uklfr.KidneyStoneAnnotator.LocationEnum",
+   "coveredText": "proximalen Ureter rechts",
+   "id": 7414,
+   "specification": {
+    "begin": 16,
+    "end": 26,
+    "type": "de.uklfr.KidneyStoneAnnotator.Specification",
+    "coveredText": "proximalen",
+    "id": 7318
+   },
+   "location": {
+    "begin": 27,
+    "end": 33,
+    "type": "de.uklfr.KidneyStoneAnnotator.Location",
+    "coveredText": "Ureter",
+    "id": 7226
+   },
+   "direction": {
+    "begin": 34,
+    "end": 40,
+    "type": "de.uklfr.KidneyStoneAnnotator.Direction",
+    "coveredText": "rechts",
+    "id": 7290
+   }
+  }
  }
 ]

--- a/tests/test_ahd_to_observation_kidney_stone.py
+++ b/tests/test_ahd_to_observation_kidney_stone.py
@@ -1,0 +1,33 @@
+import pytest
+
+from ahd2fhir.mappers.ahd_to_observation_kidney_stone import (
+    AHD_TYPE,
+    get_fhir_resources,
+)
+from tests.utils import map_resources
+
+AHD_PAYLOADS_EXPECTED_NUMBER_OF_OBSERVATIONS = [
+    ("payload_1.json", 3),
+    ("payload_2.json", 0),
+]
+
+
+@pytest.mark.parametrize(
+    "ahd_json_path,expected_number_of_observations",
+    AHD_PAYLOADS_EXPECTED_NUMBER_OF_OBSERVATIONS,
+)
+def test_maps_to_expected_number_of_condition_resources(
+    ahd_json_path, expected_number_of_observations
+):
+    observations = map_resources(ahd_json_path, AHD_TYPE, get_fhir_resources)
+    assert len(observations) == expected_number_of_observations
+
+
+@pytest.mark.parametrize(
+    "ahd_json_path,_",
+    AHD_PAYLOADS_EXPECTED_NUMBER_OF_OBSERVATIONS,
+)
+def test_mapped_observation_coding_should_set_userselected_to_false(ahd_json_path, _):
+    observations = map_resources(ahd_json_path, AHD_TYPE, get_fhir_resources)
+    for o in observations:
+        assert all(coding.userSelected is False for coding in o[0].code.coding)

--- a/tests/test_ahd_to_observation_smkstat.py
+++ b/tests/test_ahd_to_observation_smkstat.py
@@ -1,0 +1,43 @@
+import pytest
+
+from ahd2fhir.mappers.ahd_to_observation_smkstat import AHD_TYPE, get_fhir_resources
+from tests.utils import map_resources
+
+AHD_PAYLOADS_EXPECTED_NUMBER_OF_CONDITIONS = [
+    ("payload_1.json", 3),
+    ("payload_2.json", 0),
+]
+
+
+@pytest.mark.parametrize(
+    "ahd_json_path,expected_number_of_conditions",
+    AHD_PAYLOADS_EXPECTED_NUMBER_OF_CONDITIONS,
+)
+def test_maps_to_expected_number_of_condition_resources(
+    ahd_json_path, expected_number_of_conditions
+):
+
+    observations = map_resources(ahd_json_path, AHD_TYPE, get_fhir_resources)
+    assert len(observations) == expected_number_of_conditions
+
+
+@pytest.mark.parametrize(
+    "ahd_json_path,_",
+    AHD_PAYLOADS_EXPECTED_NUMBER_OF_CONDITIONS,
+)
+def test_mapped_condition_coding_should_set_userselected_to_false(ahd_json_path, _):
+    observations = map_resources(ahd_json_path, AHD_TYPE, get_fhir_resources)
+    for o in observations:
+        assert all(coding.userSelected is False for coding in o.code.coding)
+
+
+@pytest.mark.parametrize(
+    "ahd_json_path,_",
+    AHD_PAYLOADS_EXPECTED_NUMBER_OF_CONDITIONS,
+)
+def test_mapped_condition_coding_includes_snomed_and_loin(ahd_json_path, _):
+    observations = map_resources(ahd_json_path, AHD_TYPE, get_fhir_resources)
+
+    for o in observations:
+        assert o.valueCodeableConcept.coding[0].system == "http://loinc.org"
+        assert o.valueCodeableConcept.coding[1].system == "http://snomed.info/sct"

--- a/tests/test_resource_handler.py
+++ b/tests/test_resource_handler.py
@@ -18,10 +18,10 @@ class MockPipeline:
         else:
             self.response = response
 
-    def analyse_text(self, text: str, language: str):
+    def analyse_text(self, text: str, language: str, annotation_types: str):
         return self.response
 
-    def analyse_html(self, text: str, language: str):
+    def analyse_html(self, text: str, language: str, annotation_types: str):
         return self.response
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,9 @@
+import json
+from typing import Callable
+
 from fhir.resources.attachment import Attachment
 from fhir.resources.documentreference import DocumentReference, DocumentReferenceContent
 from fhir.resources.reference import Reference
-from typing import Callable
-import json
 
 
 def get_empty_document_reference():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,8 @@
 from fhir.resources.attachment import Attachment
 from fhir.resources.documentreference import DocumentReference, DocumentReferenceContent
 from fhir.resources.reference import Reference
+from typing import Callable
+import json
 
 
 def get_empty_document_reference():
@@ -16,3 +18,16 @@ def get_empty_document_reference():
     docref.id = "empty-document"
 
     return docref
+
+
+def map_resources(ahd_json_path: str, ahd_type: str, func: Callable) -> list:
+    with open(f"tests/resources/ahd/{ahd_json_path}") as file:
+        ahd_payload = json.load(file)
+
+    resources = []
+    for val in ahd_payload:
+        if val["type"] == ahd_type:
+            resource = func(val, get_empty_document_reference())
+            if resource is not None:
+                resources.append(resource)
+    return resources


### PR DESCRIPTION
To enable the usage of custom mappers i would like to propose a [hook](https://github.com/miracum/ahd2fhir/compare/master...uklft:uklfr-annotators?expand=1#diff-b6a2a7e6bccf573109ba3c9a6da20d2bec30463d64d3eb9c646973931f96436eR244) in the main loop of `_process_documentreference` that calls user-defined functions on the current `averbis_result`.

To add the least possible amount of code to the core logic i created the file [`custom_mappers.py`](https://github.com/miracum/ahd2fhir/compare/master...uklft:uklfr-annotators?expand=1#diff-2dee9a8c494f951d599557079245f09d8ee182d37e6466162ff0bb2b8bead586) that holds a dictionary of averbis types and mapper functions to be called on the corresponding averbis annotation.
This would also allow to modularize the existing mappers.

Also this PR includes mappings for custom types (smoking status, kidneystones).

If this is an acceptible way to include custom mappers i am happy to further enhance this approach :)

__Note:__ I recreated the changes from [here](https://github.com/miracum/ahd2fhir/pull/10) as new branch in the main repo 