### PR TITLE
Fix kafka fastapi concurrency metrics and logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM winnerokay/uvicorn-gunicorn-fastapi:python3.9-slim AS release
-WORKDIR /opt/ahd2fhir
+FROM ghcr.io/br3ndonland/inboard:fastapi-python3.9 AS release
+WORKDIR /app/
 COPY requirements.txt .
 RUN pip install --no-cache-dir  -r requirements.txt
 
@@ -11,11 +11,11 @@ RUN PYTHONPATH=${PWD}/ahd2fhir pytest --cov=ahd2fhir && \
     coverage report --fail-under=80
 
 FROM release
-COPY . /app
+COPY . .
 ARG VERSION=0.0.0
 ENV APP_VERSION=${VERSION} \
     PORT=8080 \
-    MODULE_NAME=ahd2fhir.main
+    APP_MODULE=ahd2fhir.main:app
 EXPOSE 8080
 USER 11111
 LABEL maintainer="miracum.org"

--- a/ahd2fhir/logging_setup.py
+++ b/ahd2fhir/logging_setup.py
@@ -1,0 +1,76 @@
+import logging.config
+from typing import Tuple
+
+import structlog
+import uvicorn
+
+# via https://github.com/simonw/datasette/issues/1175#issuecomment-762488336
+
+shared_processors: Tuple[structlog.types.Processor, ...] = (
+    structlog.contextvars.merge_contextvars,
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.add_log_level,
+    structlog.processors.TimeStamper(fmt="iso"),
+)
+
+logging_config = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "console": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.processors.KeyValueRenderer(
+                key_order=["timestamp", "level", "event"]
+            ),
+            "foreign_pre_chain": shared_processors,
+        },
+        **uvicorn.config.LOGGING_CONFIG["formatters"],
+    },
+    "handlers": {
+        "default": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "console",
+        },
+        "uvicorn.access": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "access",
+        },
+        "uvicorn.default": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "default",
+        },
+    },
+    "loggers": {
+        "": {"handlers": ["default"], "level": "INFO"},
+        "uvicorn.error": {
+            "handlers": ["uvicorn.default"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "uvicorn.access": {
+            "handlers": ["uvicorn.access"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+}
+
+
+def setup_logging() -> None:
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            *shared_processors,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        context_class=structlog.threadlocal.wrap_dict(dict),
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+    logging.config.dictConfig(logging_config)

--- a/ahd2fhir/utils/resource_handler.py
+++ b/ahd2fhir/utils/resource_handler.py
@@ -16,7 +16,7 @@ from fhir.resources.fhirtypes import DateTime
 from fhir.resources.identifier import Identifier
 from fhir.resources.reference import Reference
 from fhir.resources.resource import Resource
-from prometheus_client import Counter, Summary
+from prometheus_client import Counter, Histogram, Summary
 from tenacity import stop, wait
 from tenacity.after import after_log
 
@@ -27,7 +27,25 @@ from ahd2fhir.utils.device_builder import build_device
 from ahd2fhir.utils.fhir_utils import sha256_of_identifier
 
 MAPPING_FAILURES_COUNTER = Counter("mapping_failures", "Exceptions during mapping")
-MAPPING_DURATION_SUMMARY = Summary("map_duration_seconds", "Time spent mapping")
+MAPPING_DURATION_SUMMARY = Histogram(
+    "map_duration_seconds",
+    "Time spent mapping",
+    buckets=(
+        1.0,
+        2.0,
+        5.0,
+        8.0,
+        13.0,
+        21.0,
+        34.0,
+        55.0,
+        89.0,
+        144.0,
+        233.0,
+        377.0,
+        "inf",
+    ),
+)
 EXTRACTED_RESOURCES_COUNT_SUMMARY = Summary(
     "extracted_resources", "Number of extracted resources for each processed document"
 )


### PR DESCRIPTION
Partial work on #21. While this does allow both to run at the same time, while Kafka messages are processed, no HTTP requests are served. So occassionally the readiness probe may time out or scraping metrics may fail.